### PR TITLE
first attempt at a single/multi-column toggle for folder contents

### DIFF
--- a/substanced/folder/templates/contents.pt
+++ b/substanced/folder/templates/contents.pt
@@ -40,24 +40,56 @@
           -- all --
         </label>
 
-        <div id="choices">
+        <div id="choices" class="row" tal:condition="not batch.multicolumn">
 
-          <tal:loop tal:repeat="choice batch.items">
-            <tal:block condition="choice['viewable']">
-              <label class="checkbox" for="delete-${repeat.choice.index}">
-                <i class="${choice['icon']}"> </i>
-                <input tal:attributes="disabled not choice['deletable']"
-                       type="checkbox"
-                       name="delete"
-                       value="${choice['name']}"
-                       id="delete-${repeat.choice.index}"/>
-                <a href="${choice['url']}">${choice['name']}</a>
-              </label>
-            </tal:block>
-          </tal:loop>
+          <div class="span3">
+            <tal:loop tal:repeat="choice batch.items">
+              <tal:block condition="choice['viewable']">
+                <label class="checkbox" for="delete-${repeat.choice.index}">
+                  <i class="${choice['icon']}"> </i>
+                  <input tal:attributes="disabled not choice['deletable']"
+                         type="checkbox"
+                         name="delete"
+                         value="${choice['name']}"
+                         id="delete-${repeat.choice.index}"/>
+                  <a href="${choice['url']}">${choice['name']}</a>
+                </label>
+              </tal:block>
+            </tal:loop>
+          </div>
 
         </div>
 
+        <div id="choices" tal:condition="batch.multicolumn">
+
+          <div class="row-fluid" tal:define="position 0">
+            <tal:loop tal:repeat="column batch.make_columns()">
+              <div class="span3">
+                <tal:loop tal:repeat="choice column">
+                  <tal:block condition="choice['viewable']">
+                    <label class="checkbox" for="delete-${position}">
+                      <i class="${choice['icon']}"> </i>
+                      <input tal:attributes="disabled not choice['deletable']"
+                             type="checkbox"
+                             name="delete"
+                             value="${choice['name']}"
+                             id="delete-${position}"/>
+                      <a href="${choice['url']}">${choice['name']}</a>
+                    </label>
+                  </tal:block>
+                  <?python position += 1 ?>
+                </tal:loop>
+              </div>
+            </tal:loop>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="row-fluid" tal:condition="batch.required">
+        <div class="span2">
+          <a class="btn" href="${batch.toggle_url}">${batch.toggle_text}</a>
+        </div>
       </div>
 
       <input type="hidden" name="csrf_token" 
@@ -85,7 +117,6 @@
           </ul>
         </div>
       </div>
-
       </fieldset>
      </form>
 

--- a/substanced/util/tests.py
+++ b/substanced/util/tests.py
@@ -183,6 +183,28 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(inst.items, seq)
         self.assertEqual(inst.size, 15)
 
+    def test_it_multicolumn_toggle_text(self):
+        seq = [1,2,3,4,5,6]
+        request = testing.DummyRequest()
+        request.params['multicolumn'] = 'True'
+        inst = self._makeOne(seq, request)
+        self.assertEqual(inst.toggle_text, 'Single column')
+
+    def test_it_not_multicolumn_toggle_text(self):
+        seq = [1,2,3,4,5,6]
+        request = testing.DummyRequest()
+        request.params['multicolumn'] = 'False'
+        inst = self._makeOne(seq, request)
+        self.assertEqual(inst.toggle_text, 'Multi-column')
+
+    def test_it_make_columns(self):
+        seq = [1,2,3,4,5,6]
+        request = testing.DummyRequest()
+        inst = self._makeOne(seq, request)
+        cols = inst.make_columns(column_size=2, num_columns=3)
+        expected = [ [1,2], [3,4], [5,6] ]
+        self.assertEqual(cols, expected)
+
 class Test_merge_url_qs(unittest.TestCase):
     def _callFUT(self, url, **kw):
         from . import merge_url_qs


### PR DESCRIPTION
I added functionality to substanced.util.Batch to accommodate a toggle link for multi-column and single column views, including test coverage (although it could likely use a couple of additional tests, so let me know what you think and I can add them).

Note: the div id="choices" section of contents.pt appears to have changed dramatically, but the large diff is the result of wrapping it in another div element and indenting each line to accommodate the change. The benefit to wrapping it in the extra div is that you need to click inside that div to check a checkbox, rather than being able to accidentally check boxes by clicking on the other side of the screen.
