### PR TITLE
setting disabled attribute correctly in 'add'-button in sdi

### DIFF
--- a/substanced/widget/templates/form.pt
+++ b/substanced/widget/templates/form.pt
@@ -39,7 +39,7 @@
     <div class="form-actions">
       <tal:block repeat="button field.buttons">
         <button
-            tal:attributes="disabled button.disabled"
+            tal:attributes="disabled 'disabled' if button.disabled else None"
             id="${field.formid+button.name}"
             name="${button.name}"
             type="${button.type}"


### PR DESCRIPTION
When button.disabled == False, behavior was non-deterministic:
Sometimes the 'disabled'-attribute was set to the empty string.
This caused browsers to render the button as disabled.

There might also be other buttons in substanced where this needs
to be fixed.

The bug seems to be copied from deform:

https://github.com/Pylons/deform/blob/master/deform/templates/form.pt
