### PR TITLE
Safely allow non-privileged users to update their preferences.

### DIFF
--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -51,6 +51,10 @@ sdi.manage-references
   Protects views which allow users to manage the references associated with a
   resource.
 
+sdi.manage-user-groups
+
+  Protects views which allow admin users to update groups for users.
+
 sdi.manage-workflow
 
   Protects the views associated with managing the workflows of an object.

--- a/substanced/principal/__init__.py
+++ b/substanced/principal/__init__.py
@@ -321,13 +321,24 @@ class UserSchema(Schema):
         widget=tzname_widget,
         validator=colander.OneOf(_ZONES)
         )
+
+class UserPropertySheet(PropertySheet):
+    schema = UserSchema()
+
+class UserGroupsSchema(Schema):
+    """ Restricted schema for :class:`substanced.principal.User` objects.
+    """
     groupids = MultireferenceIdSchemaNode(
         choices_getter=groups_choices,
         title='Groups',
         )
 
-class UserPropertySheet(PropertySheet):
-    schema = UserSchema()
+class UserGroupsPropertySheet(PropertySheet):
+    schema = UserGroupsSchema()
+    permissions = (
+        ('view', 'sdi.manage-user-groups'),
+        ('change', 'sdi.manage-user-groups'),
+        )
 
 @content(
     'User',
@@ -335,7 +346,8 @@ class UserPropertySheet(PropertySheet):
     add_view='add_user',
     tab_order=('properties',),
     propertysheets = (
-        ('', UserPropertySheet),
+        ('Preferences', UserPropertySheet),
+        ('Groups', UserGroupsPropertySheet),
         )
     )
 @implementer(IUser)

--- a/substanced/principal/subscribers.py
+++ b/substanced/principal/subscribers.py
@@ -32,7 +32,10 @@ def user_added(event):
     # AttributeError.
     set_acl(
         user,
-        [(Allow, user_oid, ('sdi.view', 'sdi.change-password'))],
+        [(Allow, user_oid, ('sdi.view',
+                            'sdi.edit-properties',
+                            'sdi.change-password',
+                           ))],
         registry=event.registry,
         )
     # When set_acl is called, it will end up sending an ACLModified event,

--- a/substanced/principal/tests/test_subscribers.py
+++ b/substanced/principal/tests/test_subscribers.py
@@ -123,8 +123,10 @@ class Test_user_added(unittest.TestCase):
         self._callFUT(event)
         self.assertEqual(
             user.__acl__,
-            [(Allow, 1, ('sdi.view', 'sdi.change-password'))]
-            )
+            [(Allow, 1, ('sdi.view',
+                         'sdi.edit-properties',
+                         'sdi.change-password',
+                        ))])
 
 class Test_acl_maybe_added(unittest.TestCase):
     def _callFUT(self, event):

--- a/substanced/principal/views.py
+++ b/substanced/principal/views.py
@@ -2,6 +2,7 @@ import colander
 import deform.widget
 
 from pyramid.httpexceptions import HTTPFound
+from pyramid.security import Allow
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from ..form import FormView
@@ -18,12 +19,13 @@ from ..sdi import mgmt_view
 
 from . import (
     UserSchema,
+    UserGroupsSchema,
     GroupSchema,
     )
 
 from ..util import find_service
 
-class AddUserSchema(UserSchema):
+class AddUserSchema(UserGroupsSchema, UserSchema):
     password = colander.SchemaNode(
         colander.String(),
         widget = deform.widget.CheckedPasswordWidget(),


### PR DESCRIPTION
- Grant them 'sdi.edit-properties' on their own user object.
- Move the 'groupids' field to a new propertysheet, protected by a new
  'sdi.manage-user-groups' permission.
- Still allow admin to set groups during the add view.

Fixes #140.
