### PR TITLE
Make sure we include scaffolding templates when packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,17 @@
 graft substanced/scaffolds/substanced
+graft demos/blog/blog/static
+graft demos/blog/blog/views/templates
+graft substanced/audit/templates
+graft substanced/catalog/views/templates
+graft substanced/db/templates
+graft substanced/file/templates
+graft substanced/folder/static
+graft substanced/folder/templates
+graft substanced/objectmap/templates
+graft substanced/principal/templates
+graft substanced/property/templates
+graft substanced/sdi/static
+graft substanced/sdi/static
+graft substanced/sdi/views/templates
+graft substanced/sdi/views/templates
+graft substanced/workflow/templates


### PR DESCRIPTION
This patch fix error when calling :

``` bash
$ pcreate -s substanced myproj
Traceback (most recent call last):
  File "/home/ticosax/.virtualenvs/sandbox/bin/pcreate", line 9, in <module>
    load_entry_point('pyramid==1.5a2', 'console_scripts', 'pcreate')()
  File "/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/pyramid-1.5a2-py2.7.egg/pyramid/scripts/pcreate.py", line 16, in main
    return command.run()
  File "/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/pyramid-1.5a2-py2.7.egg/pyramid/scripts/pcreate.py", line 75, in run
    return self.render_scaffolds()
  File "/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/pyramid-1.5a2-py2.7.egg/pyramid/scripts/pcreate.py", line 93, in render_scaffolds
    scaffold.run(self, output_dir, vars)
  File "/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/pyramid-1.5a2-py2.7.egg/pyramid/scaffolds/template.py", line 65, in run
    self.write_files(command, output_dir, vars)
  File "/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/pyramid-1.5a2-py2.7.egg/pyramid/scaffolds/template.py", line 97, in write_files
    template_renderer=self.render_template,
  File "/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/pyramid-1.5a2-py2.7.egg/pyramid/scaffolds/copydir.py", line 63, in copy_dir
    names = sorted(os.listdir(source))
OSError: [Errno 2] No such file or directory: '/home/ticosax/.virtualenvs/sandbox/local/lib/python2.7/site-packages/substanced-0.0-py2.7.egg/substanced/scaffolds/substanced'
```
