### PR TITLE
Path index improvements

### DIFF
--- a/substanced/catalog/indexes.py
+++ b/substanced/catalog/indexes.py
@@ -279,6 +279,9 @@ class PathIndex(SDIndex, hypatia.util.BaseIndexMixin, Persistent):
 
     applyEq = apply
 
+    def applyNotEq(self, *args, **kw):
+        return self._negate(self.applyEq, *args, **kw)
+
     def eq(self, path, depth=None, include_origin=None):
         val = {'path':path}
         if depth is not None:
@@ -286,6 +289,14 @@ class PathIndex(SDIndex, hypatia.util.BaseIndexMixin, Persistent):
         if include_origin is not None:
             val['include_origin'] = include_origin
         return hypatia.query.Eq(self, val)
+
+    def noteq(self, path, depth=None, include_origin=None):
+        val = {'path':path}
+        if depth is not None:
+            val['depth'] = depth
+        if include_origin is not None:
+            val['include_origin'] = include_origin
+        return hypatia.query.NotEq(self, val)
 
 class IndexSchema(Schema):
     """ The property schema for :class:`substanced.principal.Group`

--- a/substanced/catalog/tests/test_indexes.py
+++ b/substanced/catalog/tests/test_indexes.py
@@ -415,6 +415,32 @@ class TestPathIndex(unittest.TestCase):
             {'path': '/abc', 'depth': 1}
             )
 
+    def test_noteq_defaults(self):
+        inst = self._makeOne()
+        result = inst.noteq('/abc')
+        self.assertEqual(
+            result._value,
+            {'path': '/abc'}
+            )
+
+    def test_noteq_include_origin_is_False(self):
+        inst = self._makeOne()
+        inst.depth = 10
+        result = inst.noteq('/abc', include_origin=False)
+        self.assertEqual(
+            result._value,
+            {'path': '/abc', 'include_origin': False}
+            )
+
+    def test_eq_include_depth_is_not_None(self):
+        inst = self._makeOne()
+        inst.depth = 10
+        result = inst.noteq('/abc', depth=1)
+        self.assertEqual(
+            result._value,
+            {'path': '/abc', 'depth': 1}
+            )
+
 class TestFieldIndex(unittest.TestCase):
     def _makeOne(self, discriminator=None, family=None, action_mode=None):
         from ..indexes import FieldIndex


### PR DESCRIPTION
Commit messages should be self-explainatory.

NOTE: I didn't test `applyNotEq` as I have no idea how to unittest it (without making the test completely useless).
