### PR TITLE
Fix for issues 191 and 194 (folder contents not always refreshing properly when changing filter)

### DIFF
--- a/substanced/folder/static/js/sdi.grid.remotemodel.js
+++ b/substanced/folder/static/js/sdi.grid.remotemodel.js
@@ -325,9 +325,12 @@
             if (query.from !== undefined) {   // query = {}, if there is no need to fetch
 
                 // Prepare the options, include the query for missing data.
+                // By default remove the original query string to prevent
+                // params e.g., 'filter.' from being overridden by existing
+                // url params
                 var ajaxOptions = {
                     type: 'GET',
-                    url: options.url,
+                    url: options.url || document.location.href.split('?')[0],
                     data: query,
                     dataType: 'json'
                 };

--- a/substanced/folder/static/js/slickgrid-config.js
+++ b/substanced/folder/static/js/slickgrid-config.js
@@ -151,7 +151,7 @@
             // we define a method on the wrapper instance, callable externally:
             this.setSearchString = function (txt) {
                 sdiRemoteModelPlugin.setFilterArgs({
-                    filter: txt
+                    'filter.': txt
                 });
             };
 
@@ -180,9 +180,7 @@
                 reallyAbort: wrapperOptions.reallyAbort,
                 sortCol: wrapperOptions.sortCol,
                 sortDir: wrapperOptions.sortDir,
-                extraQuery: {
-                    filter: ''
-                },
+                extraQuery: {},
                 minimumLoad: wrapperOptions.minimumLoad
             });
             grid.registerPlugin(sdiRemoteModelPlugin);


### PR DESCRIPTION
- Prevent url params from overriding filter params
- Use name 'filter.' consistently for the filter field
