### PR TITLE
Fixed bug by appending rss.xml/index.atom after a url of BlogEntryView of the demo blog app.

### DIFF
--- a/demos/blog/blog/views/retail.py
+++ b/demos/blog/blog/views/retail.py
@@ -103,6 +103,9 @@ def download_attachment(context, request):
     response = Response(headerlist=headers, app_iter=f)
     return response
 
+@view_defaults(
+    content_type='Root',
+    )
 class FeedViews(object):
     def __init__(self, context, request):
         self.context = context


### PR DESCRIPTION
When user append 'rss.xml' or 'index.atom' after the url of a blog entry,
the app will cause error.

For instance, If there is a blog entry named 'test_entry' and user can
access to '/test_entry' and then user access to '/test_entry/index.atom',
the blog app will cause AttributeError due to try to access 'sdi_title' attribute
of 'Blog Entry' object.

So in this changeset, I applied 'context_type' setting to FeedView to ensure
the views appear on root of the site.

The error will be like this:

```
2014-04-24 17:41:31,933 ERROR [waitress][Dummy-4] Exception when serving /test_entry/index.atom
Traceback (most recent call last):
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/waitress-0.8.8-py2.7.egg/waitress/channel.py", line 337, in service
    task.service()
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/waitress-0.8.8-py2.7.egg/waitress/task.py", line 173, in service
    self.execute()
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/waitress-0.8.8-py2.7.egg/waitress/task.py", line 392, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid-1.5-py2.7.egg/pyramid/router.py", line 242, in __call__
    response = self.invoke_subrequest(request, use_tweens=True)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid-1.5-py2.7.egg/pyramid/router.py", line 217, in invoke_subrequest
    response = handle_request(request)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid-1.5-py2.7.egg/pyramid/tweens.py", line 21, in excview_tween
    response = handler(request)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid_tm-0.7-py2.7.egg/pyramid_tm/__init__.py", line 82, in tm_tween
    reraise(*exc_info)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid_tm-0.7-py2.7.egg/pyramid_tm/__init__.py", line 63, in tm_tween
    response = handler(request)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid-1.5-py2.7.egg/pyramid/router.py", line 163, in handle_request
    response = view_callable(context, request)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid-1.5-py2.7.egg/pyramid/config/views.py", line 355, in rendered_view
    result = view(context, request)
  File "/Users/hirokiky/dev/substanced/env/lib/python2.7/site-packages/pyramid-1.5-py2.7.egg/pyramid/config/views.py", line 491, in _class_view
Fixed bug by appending rss.xml/index.atom after a url of BlogEntryView.
    response = getattr(inst, attr)()
  File "/Users/hirokiky/dev/substanced/substanced/demos/blog/blog/views/retail.py", line 171, in blog_atom
    renderer='templates/atom.pt',
  File "/Users/hirokiky/dev/substanced/substanced/demos/blog/blog/views/retail.py", line 122, in _get_feed_info
    feed = {"rss_url": request.application_url + "/rss.xml",
AttributeError: 'BlogEntry' object has no attribute 'sdi_title'
```
