### PR TITLE
Omit the "Upload" tab for folders which can not contain files

### DIFF
--- a/docs/folder_contents.rst
+++ b/docs/folder_contents.rst
@@ -241,6 +241,8 @@ is passed to this function, along with the folder and request. If *any one*
 of the folder subobjects returns ``False`` for this call, the button will
 not be enabled.
 
+.. _filtering-what-can-be-added:
+
 Filtering What Can Be Added
 ===========================
 
@@ -432,5 +434,3 @@ example:
        pass
 
    MyCoolResource = MySuperVeryCoolResource # bw compat alias
-
-

--- a/substanced/folder/tests/test_util.py
+++ b/substanced/folder/tests/test_util.py
@@ -1,6 +1,7 @@
 
 import unittest
 
+from pyramid import testing
 
 class Test_slugify_in_context(unittest.TestCase):
     def _callFUT(self, context, name, remove_extension=True):
@@ -62,3 +63,54 @@ class Test_slugify_in_context(unittest.TestCase):
             self._callFUT(context, 'boo.pdf', remove_extension=False),
             'boo-pdf-3'
             )
+
+
+class Test_content_type_addable(unittest.TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def call_it(self, context, request, content_type):
+        from ..util import content_type_addable
+        return content_type_addable(context, request, content_type)
+
+    def test_true_if_sdi_addable_is_none(self):
+        config = self.config
+        config.include('substanced.content')
+        config.add_content_type('Some Type', object)
+        context = testing.DummyResource(__sdi_addable__=None)
+        request = testing.DummyRequest()
+        self.assertTrue(self.call_it(context, request, 'Some Type'))
+
+    def test_with_callable_sdi_addable(self):
+        config = self.config
+        config.include('substanced.content')
+        config.add_content_type('Type1', object, addable=True)
+        config.add_content_type('Type2', object, addable=False)
+
+        def addable(context, intr):
+            meta = intr['meta']
+            return meta.get('addable', False)
+
+        context = testing.DummyResource(__sdi_addable__=addable)
+        request = testing.DummyRequest()
+        self.assertTrue(self.call_it(context, request, 'Type1'))
+        self.assertFalse(self.call_it(context, request, 'Type2'))
+
+    def test_with_sequence_sdi_addable(self):
+        config = self.config
+        config.include('substanced.content')
+        config.add_content_type('Type1', object)
+        config.add_content_type('Type2', object)
+
+        context = testing.DummyResource(__sdi_addable__=('Type1',))
+        request = testing.DummyRequest()
+        self.assertTrue(self.call_it(context, request, 'Type1'))
+        self.assertFalse(self.call_it(context, request, 'Type2'))
+
+    def test_false_if_content_type_unknown(self):
+        context = testing.DummyResource()
+        request = testing.DummyRequest()
+        self.assertFalse(self.call_it(context, request, 'Unknown'))

--- a/substanced/folder/util.py
+++ b/substanced/folder/util.py
@@ -4,6 +4,7 @@ import os
 import unidecode
 
 from substanced._compat import u
+from substanced.sdi import default_sdi_addable
 
 re_word = re.compile(r'\W+')
 
@@ -21,3 +22,30 @@ def slugify_in_context(context, name, remove_extension=True):
         slug = '%s-%i' % (orig, i)
         i += 1
     return slug
+
+
+def content_type_addable(context, request, content_type):
+    """Determine whether resources of type ``content_type`` can be added
+    to ``context`` using the SDI management interface.
+
+    Returns ``True`` iff resources of the type named by ``content_type`` can be
+    added to ``context`` using the SDI management interface.
+
+    Addability is determined by consulting the ``__sdi_addable__``
+    attribute of the ``context``.  See
+    :ref:`filtering-what-can-be-added` for details.p
+
+    """
+    introspector = request.registry.introspector
+    discrim = ('sd-content-type', content_type)
+    intr = introspector.get('substance d content types', discrim)
+    if intr is None:
+        return False            # unknown content_type
+
+    sdi_addable = getattr(context, '__sdi_addable__', default_sdi_addable)
+    if sdi_addable is None:
+        return True
+    elif callable(sdi_addable):
+        return sdi_addable(context, intr)
+    else:
+        return content_type in sdi_addable

--- a/substanced/folder/views.py
+++ b/substanced/folder/views.py
@@ -32,7 +32,10 @@ from ..sdi import (
     sdi_mgmt_views,
     RIGHT,
     )
-from .util import slugify_in_context
+from .util import (
+    content_type_addable,
+    slugify_in_context,
+    )
 from ..util import _
 
 from . import FolderKeyError
@@ -1446,7 +1449,7 @@ def add_folder_contents_views(
     context=IFolder,
     name='upload',
     tab_title=_('Upload'),
-    tab_condition=True,
+    tab_condition=functools.partial(content_type_addable, content_type='File'),
     tab_after='contents',
     permission='sdi.add-content',
     renderer='substanced.folder:templates/multiupload.pt'


### PR DESCRIPTION
This patch omits the _Upload_ tab on the SDI contents view in the case that ``File`` resources are not addable to the context.  The multi-upload view, as it currently stands, can only be used to create ``File`` resources, so there's no point of showing it if the context does not accept them.

For example, the _Upload_ tab makes no sense on the [SDI view of the catalogs service](http://demo.substanced.net/manage/catalogs/@@contents).