### PR TITLE
Improvements to PR #246 (hiding the "Upload" tab)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -124,3 +124,5 @@ Contributors
 - Cédric Messiant, 2014/6/2
 
 - Matt Russell, 2014/12/13
+
+- Geoffrey T. Dairiki, 2015/05/02

--- a/substanced/file/views.py
+++ b/substanced/file/views.py
@@ -75,6 +75,7 @@ def name_or_file(node, kw):
     tab_title='Add File', 
     permission='sdi.add-content', 
     renderer='substanced.sdi:templates/form.pt',
+    sdi_addable='File',
     tab_condition=False
     )
 class AddFileView(FormView):

--- a/substanced/file/views.py
+++ b/substanced/file/views.py
@@ -75,7 +75,7 @@ def name_or_file(node, kw):
     tab_title='Add File', 
     permission='sdi.add-content', 
     renderer='substanced.sdi:templates/form.pt',
-    sdi_addable='File',
+    addable_content='File',
     tab_condition=False
     )
 class AddFileView(FormView):

--- a/substanced/folder/__init__.py
+++ b/substanced/folder/__init__.py
@@ -51,7 +51,7 @@ from ..util import (
     )
 from .._compat import STRING_TYPES
 from .._compat import u
-from .util import content_type_addable
+from .util import is_sdi_addable
 
 
 class FolderKeyError(KeyError):
@@ -944,7 +944,7 @@ class _AddablePredicate(object):
     phash = text
 
     def __call__(self, context, request):
-        return any(content_type_addable(context, request, content_type)
+        return any(is_sdi_addable(context, request, content_type)
                    for content_type in self.val)
 
 def includeme(config): # pragma: no cover

--- a/substanced/folder/__init__.py
+++ b/substanced/folder/__init__.py
@@ -931,7 +931,7 @@ class CopyHook(object):
         raise ResumeCopy
 
 
-class _AddablePredicate(object):
+class _AddableContentPredicate(object):
     def __init__(self, val, config):
         if is_nonstr_iter(val):
             self.val = set(val)
@@ -939,7 +939,7 @@ class _AddablePredicate(object):
             self.val = set([val])
 
     def text(self):
-        return 'sdi_addable = %s' % ', '.join(sorted(self.val))
+        return 'addable_content = %s' % ', '.join(sorted(self.val))
 
     phash = text
 
@@ -957,6 +957,6 @@ def includeme(config): # pragma: no cover
     YEAR = 86400 * 365
     config.add_static_view('fcstatic', 'substanced.folder:static',
                            cache_max_age=YEAR)
-    config.add_view_predicate('sdi_addable', _AddablePredicate)
+    config.add_view_predicate('addable_content', _AddableContentPredicate)
     config.include('.views')
     config.include('.evolve')

--- a/substanced/folder/tests/test_init.py
+++ b/substanced/folder/tests/test_init.py
@@ -1156,16 +1156,16 @@ class Test_AddablePredicate(unittest.TestCase):
         pred = self._makeOne(['Foo', 'Bar'], config)
         self.assertEqual(pred.text(), "sdi_addable = Bar, Foo")
 
-    @mock.patch('substanced.folder.content_type_addable')
-    def test_call(self, content_type_addable):
-        content_type_addable.return_value = False
+    @mock.patch('substanced.folder.is_sdi_addable')
+    def test_call(self, is_sdi_addable):
+        is_sdi_addable.return_value = False
         config = mock.sentinel.config
         context = mock.sentinel.context
         request = mock.sentinel.request
         pred = self._makeOne('Foo', config)
         rv = pred(context, request)
         self.assertFalse(rv)
-        self.assertEqual(content_type_addable.mock_calls, [
+        self.assertEqual(is_sdi_addable.mock_calls, [
             mock.call(context, request, 'Foo'),
             ])
 

--- a/substanced/folder/tests/test_init.py
+++ b/substanced/folder/tests/test_init.py
@@ -1141,6 +1141,57 @@ class TestCopyHook(unittest.TestCase):
         inst = self._makeOne(child)
         self.assertRaises(ResumeCopy, inst, parent, None)
 
+
+class Test_is_sdi_addable(unittest.TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def call_it(self, context, request, content_type):
+        from .. import is_sdi_addable
+        return is_sdi_addable(context, request, content_type)
+
+    def test_true_if_sdi_addable_is_none(self):
+        config = self.config
+        config.include('substanced.content')
+        config.add_content_type('Some Type', object)
+        context = testing.DummyResource(__sdi_addable__=None)
+        request = testing.DummyRequest()
+        self.assertTrue(self.call_it(context, request, 'Some Type'))
+
+    def test_with_callable_sdi_addable(self):
+        config = self.config
+        config.include('substanced.content')
+        config.add_content_type('Type1', object, addable=True)
+        config.add_content_type('Type2', object, addable=False)
+
+        def addable(context, intr):
+            meta = intr['meta']
+            return meta.get('addable', False)
+
+        context = testing.DummyResource(__sdi_addable__=addable)
+        request = testing.DummyRequest()
+        self.assertTrue(self.call_it(context, request, 'Type1'))
+        self.assertFalse(self.call_it(context, request, 'Type2'))
+
+    def test_with_sequence_sdi_addable(self):
+        config = self.config
+        config.include('substanced.content')
+        config.add_content_type('Type1', object)
+        config.add_content_type('Type2', object)
+
+        context = testing.DummyResource(__sdi_addable__=('Type1',))
+        request = testing.DummyRequest()
+        self.assertTrue(self.call_it(context, request, 'Type1'))
+        self.assertFalse(self.call_it(context, request, 'Type2'))
+
+    def test_false_if_content_type_unknown(self):
+        context = testing.DummyResource()
+        request = testing.DummyRequest()
+        self.assertFalse(self.call_it(context, request, 'Unknown'))
+
 class Test_AddableContentPredicate(unittest.TestCase):
     def _makeOne(self, val, config):
         from .. import _AddableContentPredicate

--- a/substanced/folder/tests/test_init.py
+++ b/substanced/folder/tests/test_init.py
@@ -1141,20 +1141,20 @@ class TestCopyHook(unittest.TestCase):
         inst = self._makeOne(child)
         self.assertRaises(ResumeCopy, inst, parent, None)
 
-class Test_AddablePredicate(unittest.TestCase):
+class Test_AddableContentPredicate(unittest.TestCase):
     def _makeOne(self, val, config):
-        from .. import _AddablePredicate
-        return _AddablePredicate(val, config)
+        from .. import _AddableContentPredicate
+        return _AddableContentPredicate(val, config)
 
     def test_text(self):
         config = mock.sentinel.config
         pred = self._makeOne('Foo', config)
-        self.assertEqual(pred.text(), "sdi_addable = Foo")
+        self.assertEqual(pred.text(), "addable_content = Foo")
 
     def test_phash(self):
         config = mock.sentinel.config
         pred = self._makeOne(['Foo', 'Bar'], config)
-        self.assertEqual(pred.text(), "sdi_addable = Bar, Foo")
+        self.assertEqual(pred.text(), "addable_content = Bar, Foo")
 
     @mock.patch('substanced.folder.is_sdi_addable')
     def test_call(self, is_sdi_addable):

--- a/substanced/folder/tests/test_util.py
+++ b/substanced/folder/tests/test_util.py
@@ -1,7 +1,6 @@
 
 import unittest
 
-from pyramid import testing
 
 class Test_slugify_in_context(unittest.TestCase):
     def _callFUT(self, context, name, remove_extension=True):
@@ -63,54 +62,3 @@ class Test_slugify_in_context(unittest.TestCase):
             self._callFUT(context, 'boo.pdf', remove_extension=False),
             'boo-pdf-3'
             )
-
-
-class Test_is_sdi_addable(unittest.TestCase):
-    def setUp(self):
-        self.config = testing.setUp()
-
-    def tearDown(self):
-        testing.tearDown()
-
-    def call_it(self, context, request, content_type):
-        from ..util import is_sdi_addable
-        return is_sdi_addable(context, request, content_type)
-
-    def test_true_if_sdi_addable_is_none(self):
-        config = self.config
-        config.include('substanced.content')
-        config.add_content_type('Some Type', object)
-        context = testing.DummyResource(__sdi_addable__=None)
-        request = testing.DummyRequest()
-        self.assertTrue(self.call_it(context, request, 'Some Type'))
-
-    def test_with_callable_sdi_addable(self):
-        config = self.config
-        config.include('substanced.content')
-        config.add_content_type('Type1', object, addable=True)
-        config.add_content_type('Type2', object, addable=False)
-
-        def addable(context, intr):
-            meta = intr['meta']
-            return meta.get('addable', False)
-
-        context = testing.DummyResource(__sdi_addable__=addable)
-        request = testing.DummyRequest()
-        self.assertTrue(self.call_it(context, request, 'Type1'))
-        self.assertFalse(self.call_it(context, request, 'Type2'))
-
-    def test_with_sequence_sdi_addable(self):
-        config = self.config
-        config.include('substanced.content')
-        config.add_content_type('Type1', object)
-        config.add_content_type('Type2', object)
-
-        context = testing.DummyResource(__sdi_addable__=('Type1',))
-        request = testing.DummyRequest()
-        self.assertTrue(self.call_it(context, request, 'Type1'))
-        self.assertFalse(self.call_it(context, request, 'Type2'))
-
-    def test_false_if_content_type_unknown(self):
-        context = testing.DummyResource()
-        request = testing.DummyRequest()
-        self.assertFalse(self.call_it(context, request, 'Unknown'))

--- a/substanced/folder/tests/test_util.py
+++ b/substanced/folder/tests/test_util.py
@@ -65,7 +65,7 @@ class Test_slugify_in_context(unittest.TestCase):
             )
 
 
-class Test_content_type_addable(unittest.TestCase):
+class Test_is_sdi_addable(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
 
@@ -73,8 +73,8 @@ class Test_content_type_addable(unittest.TestCase):
         testing.tearDown()
 
     def call_it(self, context, request, content_type):
-        from ..util import content_type_addable
-        return content_type_addable(context, request, content_type)
+        from ..util import is_sdi_addable
+        return is_sdi_addable(context, request, content_type)
 
     def test_true_if_sdi_addable_is_none(self):
         config = self.config

--- a/substanced/folder/util.py
+++ b/substanced/folder/util.py
@@ -4,7 +4,6 @@ import os
 import unidecode
 
 from substanced._compat import u
-from substanced.sdi import default_sdi_addable
 
 re_word = re.compile(r'\W+')
 
@@ -36,6 +35,8 @@ def content_type_addable(context, request, content_type):
     :ref:`filtering-what-can-be-added` for details.p
 
     """
+    from ..sdi import default_sdi_addable  # import cycle
+
     introspector = request.registry.introspector
     discrim = ('sd-content-type', content_type)
     intr = introspector.get('substance d content types', discrim)

--- a/substanced/folder/util.py
+++ b/substanced/folder/util.py
@@ -23,7 +23,7 @@ def slugify_in_context(context, name, remove_extension=True):
     return slug
 
 
-def content_type_addable(context, request, content_type):
+def is_sdi_addable(context, request, content_type):
     """Determine whether resources of type ``content_type`` can be added
     to ``context`` using the SDI management interface.
 

--- a/substanced/folder/util.py
+++ b/substanced/folder/util.py
@@ -21,32 +21,3 @@ def slugify_in_context(context, name, remove_extension=True):
         slug = '%s-%i' % (orig, i)
         i += 1
     return slug
-
-
-def is_sdi_addable(context, request, content_type):
-    """Determine whether resources of type ``content_type`` can be added
-    to ``context`` using the SDI management interface.
-
-    Returns ``True`` iff resources of the type named by ``content_type`` can be
-    added to ``context`` using the SDI management interface.
-
-    Addability is determined by consulting the ``__sdi_addable__``
-    attribute of the ``context``.  See
-    :ref:`filtering-what-can-be-added` for details.p
-
-    """
-    from ..sdi import default_sdi_addable  # import cycle
-
-    introspector = request.registry.introspector
-    discrim = ('sd-content-type', content_type)
-    intr = introspector.get('substance d content types', discrim)
-    if intr is None:
-        return False            # unknown content_type
-
-    sdi_addable = getattr(context, '__sdi_addable__', default_sdi_addable)
-    if sdi_addable is None:
-        return True
-    elif callable(sdi_addable):
-        return sdi_addable(context, intr)
-    else:
-        return content_type in sdi_addable

--- a/substanced/folder/views.py
+++ b/substanced/folder/views.py
@@ -32,10 +32,7 @@ from ..sdi import (
     sdi_mgmt_views,
     RIGHT,
     )
-from .util import (
-    content_type_addable,
-    slugify_in_context,
-    )
+from .util import slugify_in_context
 from ..util import _
 
 from . import FolderKeyError
@@ -1449,7 +1446,8 @@ def add_folder_contents_views(
     context=IFolder,
     name='upload',
     tab_title=_('Upload'),
-    tab_condition=functools.partial(content_type_addable, content_type='File'),
+    tab_condition=True,
+    sdi_addable='File',
     tab_after='contents',
     permission='sdi.add-content',
     renderer='substanced.folder:templates/multiupload.pt'
@@ -1471,6 +1469,7 @@ def _makeob(request, stream, title, mimetype):
     request_method='POST',
     renderer='json',
     tab_condition=False,
+    sdi_addable='File',
     permission='sdi.add-content',
     )
 def multi_upload_submit(context, request):

--- a/substanced/folder/views.py
+++ b/substanced/folder/views.py
@@ -1447,7 +1447,7 @@ def add_folder_contents_views(
     name='upload',
     tab_title=_('Upload'),
     tab_condition=True,
-    sdi_addable='File',
+    addable_content='File',
     tab_after='contents',
     permission='sdi.add-content',
     renderer='substanced.folder:templates/multiupload.pt'
@@ -1469,7 +1469,7 @@ def _makeob(request, stream, title, mimetype):
     request_method='POST',
     renderer='json',
     tab_condition=False,
-    sdi_addable='File',
+    addable_content='File',
     permission='sdi.add-content',
     )
 def multi_upload_submit(context, request):


### PR DESCRIPTION
Lying in bed last night, it came to me that a better way to implement the goals of PR #246 was simply to disable the ``upload``, ``upload-submit``, and ``add_file`` views on contexts for which ``File`` resources are not sdi-addable.  (PR #246 just hides the _Upload_ tab, the views are still accessible, even though invoking these views would not be appropriate.)

This PR adds a new _view predicate_ which checks the context to see whether a specific content type is sdi-addable.  This predicate is then used to protect the previously mentioned views.  (I'm not sure that the name of the predicate, ``sdi_addable``, is the best choice.  Suggestions welcome.)

I've also renamed the new function ``content_type_addable``, introduced in #246, to ``is_sdi_addable`` to more closely match the name of the view predicate.
