### PR TITLE
Time zone support DateTime input

### DIFF
--- a/demos/blog/blog/resources.py
+++ b/demos/blog/blog/resources.py
@@ -16,6 +16,7 @@ from substanced.root import Root
 from substanced.schema import (
     Schema,
     NameSchemaNode,
+    UserTimeZoneDateTimeNode,
     )
 from substanced.util import renamer
 
@@ -40,10 +41,10 @@ class BlogEntrySchema(Schema):
         widget = deform.widget.SelectWidget(
             values=[('rst', 'rst'), ('html', 'html')]),
         )
-    pubdate = colander.SchemaNode(
-       colander.DateTime(default_tzinfo=None),
-       default = now_default,
-       )
+    pubdate = UserTimeZoneDateTimeNode(
+        default=now_default,
+    )
+
 
 class BlogEntryPropertySheet(PropertySheet):
     schema = BlogEntrySchema()
@@ -88,10 +89,9 @@ class CommentSchema(Schema):
     text = colander.SchemaNode(
        colander.String(),
        )
-    pubdate = colander.SchemaNode(
-       colander.DateTime(),
-       default = now_default,
-       )
+    pubdate = UserTimeZoneDateTimeNode(
+        default=now_default,
+    )
 
 class CommentPropertySheet(PropertySheet):
     schema = CommentSchema()

--- a/substanced/form/__init__.py
+++ b/substanced/form/__init__.py
@@ -211,5 +211,6 @@ def get_deform_renderer(search_paths):
 
 def includeme(config): # pragma: no cover
     deform_dir = resource_filename('deform', 'templates/')
-    deform_renderer = get_deform_renderer((deform_dir,))
+    substanced_dir = resource_filename('substanced', 'templates/')
+    deform_renderer = get_deform_renderer((deform_dir, substanced_dir))
     deform.Form.set_default_renderer(deform_renderer)

--- a/substanced/schema/__init__.py
+++ b/substanced/schema/__init__.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import colander
 import deform.schema
 import deform.widget
@@ -228,8 +230,17 @@ class MultireferenceIdSchemaNode(ReferenceIdSchemaNode):
 
 
 class UserTimeZoneDateTimeNode(colander.SchemaNode):
-    widget = UserTimeZoneDateTimeInputWidget()
-
     @staticmethod
     def schema_type():
         return colander.DateTime(default_tzinfo=None)
+
+    @property
+    def widget(self):
+        request = self.bindings['request']
+        if request.user:
+            timezone = request.user.timezone.localize(datetime(1991, 11, 5)).strftime("%z")
+        else:
+            timezone = ''
+        return UserTimeZoneDateTimeInputWidget(
+            timezone=timezone
+        )

--- a/substanced/schema/__init__.py
+++ b/substanced/schema/__init__.py
@@ -230,6 +230,8 @@ class MultireferenceIdSchemaNode(ReferenceIdSchemaNode):
 
 
 class UserTimeZoneDateTimeNode(colander.SchemaNode):
+    show_timezone = False
+
     @staticmethod
     def schema_type():
         return colander.DateTime(default_tzinfo=None)
@@ -242,5 +244,6 @@ class UserTimeZoneDateTimeNode(colander.SchemaNode):
         else:
             timezone = ''
         return UserTimeZoneDateTimeInputWidget(
-            timezone=timezone
+            timezone=timezone,
+            show_timezone=self.show_timezone,
         )

--- a/substanced/schema/__init__.py
+++ b/substanced/schema/__init__.py
@@ -1,9 +1,11 @@
 import colander
+import deform.schema
 import deform.widget
 
 from deform.i18n import _ as deform_i18n
 
 from ..util import get_all_permissions
+from ..widget import UserTimeZoneDateTimeInputWidget
 
 from pyramid.i18n import TranslationStringFactory
 
@@ -223,3 +225,11 @@ class ReferenceIdSchemaNode(colander.SchemaNode):
 class MultireferenceIdSchemaNode(ReferenceIdSchemaNode):
     schema_type = IdSet
     multiple = True
+
+
+class UserTimeZoneDateTimeNode(colander.SchemaNode):
+    widget = UserTimeZoneDateTimeInputWidget()
+
+    @staticmethod
+    def schema_type():
+        return colander.DateTime(default_tzinfo=None)

--- a/substanced/templates/timezonedatetimeinput.pt
+++ b/substanced/templates/timezonedatetimeinput.pt
@@ -41,7 +41,7 @@
          var d = new Date();
          var tzo = d.getTimezoneOffset() / 60 * -1;
          var dif = tzo >= 0 ? '+' : '-';
-         var formatted = tzo >= 10 ? '' : '0' + tzo + ':00';
+         var formatted = tzo >= 10 ? '' : '0' + tzo + '00';
          var timezone = dif + formatted;
          $timezone.val(timezone);
        }

--- a/substanced/templates/timezonedatetimeinput.pt
+++ b/substanced/templates/timezonedatetimeinput.pt
@@ -20,13 +20,19 @@
              tal:attributes="style style"
              id="${oid}-time"/>
     </div>
-    <div class="input-group col-xs-6">
+    <div class="input-group col-xs-6"
+         tal:condition="show_timezone">
       <span class="input-group-addon" i18n:translate="">TimeZone</span>
       <input type="text" name="timezone" value="${timezone}"
              class="span2 form-control ${css_class or ''}"
              tal:attributes="style style"
              id="${oid}-timezone">
     </div>
+    <input type="hidden" name="timezone" value="${timezone}"
+           class="span2 form-control ${css_class or ''}"
+           tal:condition="not show_timezone"
+           tal:attributes="style style"
+           id="${oid}-timezone">
   </div>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/substanced/templates/timezonedatetimeinput.pt
+++ b/substanced/templates/timezonedatetimeinput.pt
@@ -1,0 +1,51 @@
+<div i18n:domain="deform"
+      tal:omit-tag=""
+      tal:define="oid oid|field.oid;
+                  name name|field.name;
+                  css_class css_class|field.widget.css_class;
+                  style style|field.widget.style;">
+  ${field.start_mapping()}
+  <div class="row">
+    <div class="input-group col-xs-6">
+      <span class="input-group-addon" i18n:translate="">Date</span>
+      <input type="text" name="date" value="${date}"
+             class="span2 form-control ${css_class or ''} hasDatepicker"
+             tal:attributes="style style"
+             id="${oid}-date"/>
+    </div>
+    <div class="input-group col-xs-6">
+      <span class="input-group-addon" i18n:translate="">Time</span>
+      <input type="text" name="time" value="${time}"
+             class="span2 form-control ${css_class or ''} hasDatepicker"
+             tal:attributes="style style"
+             id="${oid}-time"/>
+    </div>
+    <div class="input-group col-xs-6">
+      <span class="input-group-addon" i18n:translate="">TimeZone</span>
+      <input type="text" name="timezone" value="${timezone}"
+             class="span2 form-control ${css_class or ''}"
+             tal:attributes="style style"
+             id="${oid}-timezone">
+    </div>
+  </div>
+  ${field.end_mapping()}
+  <script type="text/javascript">
+   deform.addCallback(
+     '${oid}',
+     function(oid) {
+       $('#' + oid + '-date').pickadate(${date_options_json});
+       $('#' + oid + '-time').pickatime(${time_options_json});
+
+       var $timezone = $('#' + oid + '-timezone');
+       if (!$timezone.val()) {
+         var d = new Date();
+         var tzo = d.getTimezoneOffset() / 60 * -1;
+         var dif = tzo >= 0 ? '+' : '-';
+         var formatted = tzo >= 10 ? '' : '0' + tzo + ':00';
+         var timezone = dif + formatted;
+         $timezone.val(timezone);
+       }
+     }
+   );
+  </script>
+</div>

--- a/substanced/widget/__init__.py
+++ b/substanced/widget/__init__.py
@@ -12,13 +12,16 @@ from deform.i18n import _
 
 class UserTimeZoneDateTimeInputWidget(deform_widget.DateTimeInputWidget):
     template = 'timezonedatetimeinput'
+    timezone = ''
 
     def serialize(self, field, cstruct, **kw):
         if cstruct in (null, None):
             cstruct = ''
         readonly = kw.get('readonly', self.readonly)
 
-        kw['timezone'] = ''
+        if 'timezone' not in kw:
+            kw['timezone'] = self.timezone
+
         if cstruct:
             parsed = ISO8601_REGEX.match(cstruct)
             if parsed: # strip timezone if it's there

--- a/substanced/widget/__init__.py
+++ b/substanced/widget/__init__.py
@@ -13,11 +13,15 @@ from deform.i18n import _
 class UserTimeZoneDateTimeInputWidget(deform_widget.DateTimeInputWidget):
     template = 'timezonedatetimeinput'
     timezone = ''
+    show_timezone = False
 
     def serialize(self, field, cstruct, **kw):
         if cstruct in (null, None):
             cstruct = ''
         readonly = kw.get('readonly', self.readonly)
+
+        if 'show_timezone' not in kw:
+            kw['show_timezone'] = self.show_timezone
 
         if 'timezone' not in kw:
             kw['timezone'] = self.timezone

--- a/substanced/widget/__init__.py
+++ b/substanced/widget/__init__.py
@@ -1,0 +1,88 @@
+import json
+
+from colander import (
+    Invalid,
+    null,
+)
+from colander.iso8601 import ISO8601_REGEX
+
+from deform import widget as deform_widget
+from deform.i18n import _
+
+
+class UserTimeZoneDateTimeInputWidget(deform_widget.DateTimeInputWidget):
+    template = 'timezonedatetimeinput'
+
+    def serialize(self, field, cstruct, **kw):
+        if cstruct in (null, None):
+            cstruct = ''
+        readonly = kw.get('readonly', self.readonly)
+
+        kw['timezone'] = ''
+        if cstruct:
+            parsed = ISO8601_REGEX.match(cstruct)
+            if parsed: # strip timezone if it's there
+                timezone = parsed.groupdict()['timezone']
+                if timezone and cstruct.endswith(timezone):
+                    cstruct = cstruct[:-len(timezone)]
+                    kw['timezone'] = timezone
+
+        try:
+            date, time = cstruct.split('T', 1)
+            try:
+                # get rid of milliseconds
+                time, _ = time.split('.', 1)
+            except ValueError:
+                pass
+            kw['date'], kw['time'] = date, time
+        except ValueError: # need more than one item to unpack
+            kw['date'] = kw['time'] = ''
+
+
+        date_options = dict(
+            kw.get('date_options') or self.date_options or
+            self.default_date_options
+            )
+        date_options['formatSubmit'] = 'yyyy-mm-dd'
+        kw['date_options_json'] = json.dumps(date_options)
+
+        time_options = dict(
+            kw.get('time_options') or self.time_options or
+            self.default_time_options
+            )
+        time_options['formatSubmit'] = 'HH:i'
+        kw['time_options_json'] = json.dumps(time_options)
+
+        values = self.get_template_values(field, cstruct, kw)
+        template = readonly and self.readonly_template or self.template
+        return field.renderer(template, **values)
+
+    def deserialize(self, field, pstruct):
+        if pstruct is null:
+            return null
+        else:
+            # seriously pickadate?  oh.  right.  i forgot.  you're javascript.
+            date = pstruct['date'].strip()
+            time = pstruct['time'].strip()
+            timezone = pstruct['timezone'].strip()
+            date_submit = pstruct['date_submit'].strip()
+            time_submit = pstruct['time_submit'].strip()
+
+            date = date_submit or date
+            time = time_submit or time
+
+            if (not time and not date and not timezone):
+                return null
+
+            result = 'T'.join([date, time]) + timezone
+
+            if not date:
+                raise Invalid(field.schema, _('Incomplete date'), result)
+
+            if not time:
+                raise Invalid(field.schema, _('Incomplete time'), result)
+
+            if not timezone:
+                raise Invalid(field.schema, _('Incomplete timezone'), result)
+
+            return result


### PR DESCRIPTION
refs #98
Added timezone supporting DateTime input Schema

* Use logged in user timezone
* If not, use browser timezone

By default, it won't be shown. but you can switch by passing `show_timezone` option.

## Tasks

I know its "Work In Progress".

* [ ] tests
* [ ] fixing messy codes
* [ ] docs

and If it can, separating timezone support datetime input from substanced and including on deform will be good.

If you have some opinion, everything is welcome.