### PR TITLE
fix the case in the bug report #291 where an exception was raised ins…

### DIFF
--- a/demos/blog/blog/resources.py
+++ b/demos/blog/blog/resources.py
@@ -25,7 +25,7 @@ def now_default(node, kw):
 
 class BlogEntrySchema(Schema):
     name = NameSchemaNode(
-        editing=lambda c, r: r.registry.content.istype(c, 'BlogEntry')
+        editing=lambda c, r: r.registry.content.istype(c, 'Blog Entry')
         )
     title = colander.SchemaNode(
         colander.String(),

--- a/substanced/schema/tests.py
+++ b/substanced/schema/tests.py
@@ -177,6 +177,19 @@ class TestNameSchemaNode(unittest.TestCase):
         node.bindings = bindings
         self.assertEqual(node.validator(node, 'abc'), None)
 
+    def test_it_editing_targetname_exists(self):
+        bindings = self._makeBindings()
+        parent = testing.DummyResource()
+        parent['abc'] = testing.DummyResource()
+        def check_name(value): return 'abc'
+        parent.validate_name = check_name
+        bindings['context'].__parent__ = parent
+        bindings['request'].registry.content = DummyContent(True)
+        node = self._makeOne(editing=True)
+        node.bindings = bindings
+        self.assertRaises(colander.Invalid, node.validator, node, 'abc')
+        
+
 class TestPermissionsSchemaNode(unittest.TestCase):
     def setUp(self):
         testing.setUp()


### PR DESCRIPTION
…tead of a sensible flash message being shown when an object was renamed to an existing other objects name using a propertysheet

https://github.com/Pylons/substanced/issues/291