### PR TITLE
Fix display of description

### DIFF
--- a/substanced/sdi/views/undo.py
+++ b/substanced/sdi/views/undo.py
@@ -129,6 +129,8 @@ class UndoViews(object):
             t = tz.localize(t).strftime('%Y-%m-%d %H:%M:%S %Z')
             d['time'] = t
             desc = d['description'] or b''
+            if not isinstance(desc, bytes): #pragma NO COVER Py3k
+                desc = desc.encode('ascii', 'surrogateescape')
             tid = d['id']
             un = d['user_name']
             try:


### PR DESCRIPTION
When concatenating desc and a b'  ', the following error appears with Python 3:

TypeError: must be str, not bytes

This is what happens

>>> ' ' + b' '
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: must be str, not bytes

This fixes it:

>>> ' '.encode('ascii', 'surrogateescape') + b' '
b'  '