### PR TITLE
docs: Fix a few typos

### DIFF
--- a/substanced/interfaces.py
+++ b/substanced/interfaces.py
@@ -188,7 +188,7 @@ class IEditable(Interface):
     def get():
         """ Return ``(body_iter, mimetype)`` representing the context.
 
-        - ``body_iter`` is an iterable, whose chunks are bytes represenating
+        - ``body_iter`` is an iterable, whose chunks are bytes representing
           the context as an editable file.
 
         - ``mimetype`` is the MIMEType corresponding to ``body_iter``.

--- a/substanced/sdi/static/js/buster-test/testlib/jquery-1.7.2.js
+++ b/substanced/sdi/static/js/buster-test/testlib/jquery-1.7.2.js
@@ -8509,7 +8509,7 @@ jQuery.fn.extend({
 			// will store per property easing and be used to determine when an animation is complete
 			opt.animatedProperties = {};
 
-			// first pass over propertys to expand / normalize
+			// first pass over properties to expand / normalize
 			for ( p in prop ) {
 				name = jQuery.camelCase( p );
 				if ( p !== name ) {


### PR DESCRIPTION
There are small typos in:
- substanced/interfaces.py
- substanced/sdi/static/js/buster-test/testlib/jquery-1.7.2.js

Fixes:
- Should read `representing` rather than `represenating`.
- Should read `properties` rather than `propertys`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md