### PR TITLE
fix: return type of 'tznames_widget'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 1.0b1 (unreleased)
 ==================
 
+- Fix ``tznames_widget``, b0rken seemingly forever under Python3.
+  See https://github.com/Pylons/substanced/pull/314
+
 - Drop old Python versions (< 3.8), add newer ones (up to 3.12).
   - Remove all the "straddle" compatibility stuff FBO Python 2.7
   - Pin pyramid < 2.0dev, until it can be reviewed in depth.

--- a/substanced/principal/__init__.py
+++ b/substanced/principal/__init__.py
@@ -297,8 +297,8 @@ def groups_choices(context, request):
 _ZONES = pytz.all_timezones
 
 @colander.deferred
-def tzname_widget(node, kw): #pragma NO COVER
-    return deform.widget.Select2Widget(values=zip(_ZONES, _ZONES))
+def tzname_widget(node, kw):
+    return deform.widget.Select2Widget(values=list(zip(_ZONES, _ZONES)))
 
 def get_locales():
     dir_ = os.listdir(os.path.join(os.path.dirname(__file__),

--- a/substanced/principal/tests/test_principal.py
+++ b/substanced/principal/tests/test_principal.py
@@ -5,15 +5,6 @@ import colander
 from pyramid import testing
 from zope.interface import implementer
 
-class Test_locale_widget(unittest.TestCase):
-    def _callFUT(self, node, kw):
-        from substanced.principal import locale_widget
-        return locale_widget(node, kw)
-
-    def test_it(self):
-        result = self._callFUT(None, None)
-        self.assertTrue( ('en', 'en') in result.values)
-
 class TestPrincipals(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
@@ -342,6 +333,26 @@ class Test_groups_choices(unittest.TestCase):
         request = testing.DummyRequest()
         result = self._makeOne(site, request)
         self.assertEqual(result, ())
+
+class Test_tzname_widget(unittest.TestCase):
+    def _callFUT(self, node, kw):
+        from substanced.principal import tzname_widget
+        return tzname_widget(node, kw)
+
+    def test_it(self):
+        result = self._callFUT(None, None)
+        self.assertIn(
+            ('America/New_York', 'America/New_York'), result.values
+        )
+
+class Test_locale_widget(unittest.TestCase):
+    def _callFUT(self, node, kw):
+        from substanced.principal import locale_widget
+        return locale_widget(node, kw)
+
+    def test_it(self):
+        result = self._callFUT(None, None)
+        self.assertIn( ('en', 'en'), result.values)
 
 class TestUser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
'deform.widget.SelectWidget.serialize' insists it must be an instance of 'list', 'tuple', or 'range'.

Closes #313.