### PR TITLE
refactor: move 'substanced.locking.now' to substanced.'util.now'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@
 
 - Move 'substanced.locking.now' to 'substanced.util.now', and rework to avoid
   warning spew for 'datetime.datetime.utcnow'.
- 
+
 - Suppress other warning spew from upstreams in newer Python versions
   ('chameleon' / AST, 'pkg_resources', etc.)
 
@@ -36,7 +36,7 @@
 - Override ``serialize`` for ``ReferenceIdSchemaNode``.
   See https://github.com/Pylons/substanced/pull/311
 
-- Get all tests running under ``py.test`` against head of Pyramid's 
+- Get all tests running under ``py.test`` against head of Pyramid's
   ``1.10`` branch.  See https://github.com/Pylons/substanced/pull/309
 
 - Add support for Python 3.6 and 3.7; drop support for Python 3.4.
@@ -121,7 +121,7 @@
   the change.
 
 - Removed Python 2.6 compatibility shim ``substanced._compat.total_ordering``.
-  
+
 1.0a1 (2015-04-17)
 ==================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+1.0 (unreleased)
+================
+
+- Move 'substanced.locking.now' to 'substanced.util.now', and rework to avoid
+  warning spew for 'datetime.datetime.utcnow'.
+ 
+- Suppress other warning spew from upstreams in newer Python versions
+  ('chameleon' / AST, 'pkg_resources', etc.)
+
+
 1.0b1 (2024-11-27)
 ==================
 

--- a/demos/blog/blog/views/retail.py
+++ b/demos/blog/blog/views/retail.py
@@ -7,7 +7,10 @@ from webob import Response
 from pyramid.decorator import reify
 from pyramid.httpexceptions import HTTPFound
 from pyramid.url import resource_url
-from substanced.util import find_catalog
+from substanced.util import (
+    find_catalog,
+    now,
+)
 from pyramid.view import (
     view_config,
     view_defaults,
@@ -122,11 +125,6 @@ class FeedViews(object):
         self.context = context
         self.request = request
 
-    def _nowtz(self):
-        now = datetime.datetime.utcnow() # naive
-        y, mo, d, h, mi, s = now.timetuple()[:6]
-        return datetime.datetime(y, mo, d, h, mi, s, tzinfo=pytz.utc)
-
     def _get_feed_info(self):
         context = self.context
         request = self.request
@@ -160,7 +158,7 @@ class FeedViews(object):
                 
         blogentries.sort(key=lambda x: x[0].isoformat())
         blogentries = [entry[1] for entry in reversed(blogentries)][:15]
-        updated = blogentries and blogentries[0]['pubdate'] or self._nowtz()
+        updated = blogentries and blogentries[0]['pubdate'] or now()
         _add_updated_strings(updated, feed)
         
         return feed, blogentries

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,9 @@ addopts = -l --strict
 norecursedirs = lib include .tox .git
 python_files = test_*.py tests.py
 filterwarnings =
+     ignore::DeprecationWarning:chameleon
      ignore::DeprecationWarning:pkg_resources
+     ignore:.*pkg_resources:DeprecationWarning
+     ignore:.*Attribute . is deprecated:DeprecationWarning
+     ignore::DeprecationWarning:webob
      ignore::DeprecationWarning:zodburi

--- a/substanced/audit/tests/test_views.py
+++ b/substanced/audit/tests/test_views.py
@@ -1,4 +1,6 @@
+import datetime
 import unittest
+
 from pyramid import testing
 
 class Test_AuditLogEventStreamView(unittest.TestCase):
@@ -93,11 +95,10 @@ class Test_AuditLogEventStreamView(unittest.TestCase):
         self.assertEqual(list(auditlog.oids), [3])
 
     def test_auditing(self):
-        import pytz
         context = testing.DummyResource()
         request = testing.DummyRequest()
         request.user = testing.DummyResource()
-        request.user.timezone = pytz.timezone('UTC')
+        request.user.timezone = datetime.timezone.utc
         inst = self._makeOne(context, request)
         inst.get_auditlog = lambda c: DummyAuditLog()
         result = inst.auditing()

--- a/substanced/content/test_it.py
+++ b/substanced/content/test_it.py
@@ -24,7 +24,6 @@ class TestContentRegistry(unittest.TestCase):
     def test_create(self):
         registry = DummyRegistry()
         inst = self._makeOne(registry)
-        inst._utcnow = lambda *a: 1
         content = testing.DummyResource()
         inst.content_types['dummy'] = lambda a: content
         inst.meta['dummy'] = {}
@@ -34,7 +33,6 @@ class TestContentRegistry(unittest.TestCase):
     def test_create_with_oid(self):
         registry = DummyRegistry()
         inst = self._makeOne(registry)
-        inst._utcnow = lambda *a: 1
         content = testing.DummyResource()
         inst.content_types['dummy'] = lambda a: content
         inst.meta['dummy'] = {}

--- a/substanced/locking/__init__.py
+++ b/substanced/locking/__init__.py
@@ -7,7 +7,6 @@ used by add-ons such as DAV implementations.
 
 import datetime
 import uuid
-import pytz
 
 from zope.interface import implementer
 
@@ -43,6 +42,7 @@ from substanced.util import (
     find_objectmap,
     find_service,
     get_oid,
+    now,
     )
 from substanced.schema import Schema
 
@@ -68,9 +68,6 @@ class UnlockError(LockingError):
     :class:`substanced.locking.Lock` object, representing the conflicting lock,
     or ``None`` if there was no lock to unlock.
     """
-
-def now():
-    return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
 
 class LockOwnerSchema(colander.SchemaNode):
     title = 'Owner'

--- a/substanced/locking/tests/test_init.py
+++ b/substanced/locking/tests/test_init.py
@@ -20,16 +20,6 @@ class TestUnlockError(unittest.TestCase):
         inst = self._makeOne('lock')
         self.assertEqual(inst.lock, 'lock')
 
-class Test_now(unittest.TestCase):
-    def _callFUT(self):
-        from .. import now
-        return now()
-
-    def test_it(self):
-        from pytz import UTC
-        result = self._callFUT()
-        self.assertEqual(result.tzinfo, UTC)
-
 class TestLockOwnerSchema(unittest.TestCase):
     def _makeOne(self):
         from .. import LockOwnerSchema
@@ -210,18 +200,18 @@ class TestLock(unittest.TestCase):
         self.assertEqual(inst.comment, 'comment')
 
     def test_refresh(self):
-        import datetime
+        from .. import now
         inst = self._makeOne()
-        now = datetime.datetime.utcnow()
-        inst.refresh(when=now)
-        self.assertEqual(inst.last_refresh, now)
+        NOW = now()
+        inst.refresh(when=NOW)
+        self.assertEqual(inst.last_refresh, NOW)
 
     def test_refresh_with_timeout(self):
-        import datetime
+        from .. import now
         inst = self._makeOne()
-        now = datetime.datetime.utcnow()
-        inst.refresh(timeout=30, when=now)
-        self.assertEqual(inst.last_refresh, now)
+        NOW = now()
+        inst.refresh(timeout=30, when=NOW)
+        self.assertEqual(inst.last_refresh, NOW)
         self.assertEqual(inst.timeout, 30)
 
     def test_expires_timeout_is_None(self):
@@ -231,11 +221,12 @@ class TestLock(unittest.TestCase):
 
     def test_expires_timeout_is_int(self):
         import datetime
+        from .. import now
         inst = self._makeOne()
         inst.timeout = 30
-        now = datetime.datetime.utcnow()
-        inst.last_refresh = now
-        self.assertEqual(inst.expires(), now + datetime.timedelta(seconds=30))
+        NOW = now()
+        inst.last_refresh = NOW
+        self.assertEqual(inst.expires(), NOW + datetime.timedelta(seconds=30))
 
     def test_is_valid_expires_timeout_is_None(self):
         inst = self._makeOne()
@@ -244,31 +235,34 @@ class TestLock(unittest.TestCase):
 
     def test_is_valid_expires_timeout_is_int(self):
         import datetime
+        from .. import now
         inst = self._makeOne()
         inst.timeout = 30
-        now = datetime.datetime.utcnow()
-        future = now + datetime.timedelta(seconds=60)
-        inst.last_refresh = now
-        self.assertTrue(inst.is_valid(now))
-        self.assertFalse(inst.is_valid(future))
+        NOW = now()
+        FUTURE = NOW + datetime.timedelta(seconds=60)
+        inst.last_refresh = NOW
+        self.assertTrue(inst.is_valid(NOW))
+        self.assertFalse(inst.is_valid(FUTURE))
 
     def test_is_valid_expires_resource_id_exists(self):
         import datetime
+        from .. import now
         inst = self._makeOne()
         inst.timeout = 30
-        now = datetime.datetime.utcnow()
-        inst.last_refresh = now
+        NOW = now()
+        inst.last_refresh = NOW
         inst.__objectmap__ = DummyObjectMap([1])
-        self.assertTrue(inst.is_valid(now))
+        self.assertTrue(inst.is_valid(NOW))
 
     def test_is_valid_expires_resource_id_notexist(self):
         import datetime
+        from .. import now
         inst = self._makeOne()
         inst.timeout = 30
-        now = datetime.datetime.utcnow()
-        inst.last_refresh = now
+        NOW = now()
+        inst.last_refresh = NOW
         inst.__objectmap__ = DummyObjectMap([])
-        self.assertFalse(inst.is_valid(now))
+        self.assertFalse(inst.is_valid(NOW))
 
     def test_depth_wo_infinite(self):
         inst = self._makeOne(infinite=False)

--- a/substanced/util/__init__.py
+++ b/substanced/util/__init__.py
@@ -3,6 +3,7 @@ try:
     import cProfile as _profile
 except ImportError: # pragma: no cover (pypy)
     import profile as _profile
+import datetime
 import itertools
 import json
 import math
@@ -29,6 +30,9 @@ from ..interfaces import IService
 _ = TranslationStringFactory('substanced')
 
 _marker = object()
+
+def now():
+    return datetime.datetime.now(datetime.timezone.utc)
 
 class JsonDict(dict):
     def __str__(self):

--- a/substanced/util/test_it.py
+++ b/substanced/util/test_it.py
@@ -4,6 +4,17 @@ from pyramid import testing
 
 from . import _marker
 
+class Test_now(unittest.TestCase):
+    def _callFUT(self):
+        from . import now
+        return now()
+
+    def test_it(self):
+        import datetime
+
+        result = self._callFUT()
+        self.assertIs(result.tzinfo, datetime.timezone.utc)
+
 class Test__postorder(unittest.TestCase):
     def setUp(self):
         testing.setUp()
@@ -391,8 +402,8 @@ class Test_coarse_datetime_repr(unittest.TestCase):
 
     def test_it(self):
         import calendar
-        import datetime
-        d = datetime.datetime.utcnow()
+        from . import now
+        d = now()
         result = self._callFUT(d)
         timetime = calendar.timegm(d.timetuple())
         val = int(timetime) // 100        


### PR DESCRIPTION
Rework to avoid warning spew for 'datetime.datetime.utcnow'.

Suppress other warning spew (chameleon / AST, pkg_resources, etc.)